### PR TITLE
Fix packet length format in network monitor

### DIFF
--- a/network_monitor.c
+++ b/network_monitor.c
@@ -4,7 +4,7 @@
 #include <pcap.h>
 
 void packet_handler(u_char *user, const struct pcap_pkthdr *header, const u_char *packet) {
-    printf("[Network Monitor] Captured packet of length: %d\n", header->len);
+    printf("[Network Monitor] Captured packet of length: %u\n", header->len);
     // In a real system, packet analysis would occur here.
 }
 


### PR DESCRIPTION
## Summary
- use an unsigned format specifier for packet length in `network_monitor.c`

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_6852cad94cf083299d18cbfb3c53132c