### PR TITLE
Fix README scan command

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -45,7 +45,7 @@ There are two modes to run the antivirus:
 To scan a specific file, run:
 
 ```
-/antivirus <file_to_scan>
+./antivirus <file_to_scan>
 ```
 
 The antivirus will:


### PR DESCRIPTION
## Summary
- correct scan mode command in README to use `./antivirus`

## Testing
- `make` *(fails: pcap headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_6852cad874148329901d9b883393f0fc