### PR TITLE
Integrate real malware signature feed

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # Linux Antivirus Project
 
-This project is a modular antivirus solution implemented in C for Linux. It combines several detection techniques including signature-based scanning, heuristic analysis, real-time file monitoring, process scanning, network monitoring, and file quarantine. It also features an update module that downloads malware signatures from an online source (in JSON format) using libcurl and parses them with cJSON.
+This project is a modular antivirus solution implemented in C for Linux. It combines several detection techniques including signature-based scanning, heuristic analysis, real-time file monitoring, process scanning, network monitoring, and file quarantine. It also features an update module that downloads malware signatures from an online source using libcurl.
 
 
 ## External Libraries
@@ -10,7 +10,6 @@ The project uses several external libraries:
 - **libpcap**: For capturing network packets.
 - **libcurl**: For downloading signature updates from an online source.
 - **inotify**: A Linux kernel API for real-time file system monitoring (no extra library required).
-- **cJSON**: A lightweight JSON parser for C (included as `cJSON.c` and `cJSON.h` in the project).
 
 ## Building the Project
 

--- a/update.c
+++ b/update.c
@@ -2,8 +2,8 @@
 #include "utils.h"
 #include "update.h"
 #include <curl/curl.h>
-#include "cJSON.h"
 #include <unistd.h>
+#include <ctype.h>
 
 // Global signature database.
 static char **signature_db = NULL;
@@ -39,37 +39,52 @@ void update_signatures(void) {
     curl_global_init(CURL_GLOBAL_ALL);
     curl_handle = curl_easy_init();
     if (curl_handle) {
-        // Dummy URL for the signature database.
-        curl_easy_setopt(curl_handle, CURLOPT_URL, "http://example.com/signatures.json");
+        // Open-source malware hash feed (SHA-256 hashes with descriptions)
+        curl_easy_setopt(curl_handle, CURLOPT_URL,
+                         "https://raw.githubusercontent.com/Neo23x0/signature-base/master/iocs/otx-hash-iocs.txt");
         curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, WriteMemoryCallback);
         curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, (void *)&chunk);
         res = curl_easy_perform(curl_handle);
         if (res != CURLE_OK) {
             fprintf(stderr, "[Update] curl_easy_perform() failed: %s\n", curl_easy_strerror(res));
-            // Use a dummy JSON if download fails.
-            const char *dummy_json = "{\"signatures\": [\"dummyhash1234567890abcdefdummyhash1234567890abcdef\"]}";
+            // Fallback to a minimal built-in signature
+            const char *dummy_text = "d41d8cd98f00b204e9800998ecf8427e;dummy";
             free(chunk.memory);
-            chunk.memory = strdup(dummy_json);
-            chunk.size = strlen(dummy_json);
+            chunk.memory = strdup(dummy_text);
+            chunk.size = strlen(dummy_text);
         }
-        printf("[Update] Received signature data:\n%s\n", chunk.memory);
-        cJSON *json = cJSON_Parse(chunk.memory);
-        if (json == NULL) {
-            fprintf(stderr, "[Update] Failed to parse JSON.\n");
-        } else {
-            cJSON *signatures = cJSON_GetObjectItemCaseSensitive(json, "signatures");
-            if (cJSON_IsArray(signatures)) {
-                num_signatures = cJSON_GetArraySize(signatures);
-                signature_db = malloc(num_signatures * sizeof(char *));
-                for (size_t i = 0; i < num_signatures; i++) {
-                    cJSON *sig = cJSON_GetArrayItem(signatures, i);
-                    if (cJSON_IsString(sig) && sig->valuestring != NULL) {
-                        signature_db[i] = strdup(sig->valuestring);
-                        printf("[Update] Loaded signature: %s\n", signature_db[i]);
-                    }
-                }
+        printf("[Update] Received signature data (%zu bytes)\n", chunk.size);
+
+        // Free previous database if any
+        for (size_t i = 0; i < num_signatures; i++) {
+            free(signature_db[i]);
+        }
+        free(signature_db);
+        signature_db = NULL;
+        num_signatures = 0;
+
+        // Parse lines of the feed: "HASH;description"
+        char *saveptr = NULL;
+        char *line = strtok_r(chunk.memory, "\n", &saveptr);
+        while (line) {
+            char *semi = strchr(line, ';');
+            if (semi) {
+                *semi = '\0';
             }
-            cJSON_Delete(json);
+            size_t len = strlen(line);
+            if (len == 64) {
+                for (size_t i = 0; i < len; i++) {
+                    line[i] = tolower((unsigned char)line[i]);
+                }
+                signature_db = realloc(signature_db, (num_signatures + 1) * sizeof(char *));
+                signature_db[num_signatures] = strdup(line);
+                printf("[Update] Loaded signature: %s\n", line);
+                num_signatures++;
+            }
+            line = strtok_r(NULL, "\n", &saveptr);
+        }
+        if (num_signatures == 0) {
+            fprintf(stderr, "[Update] No valid signatures loaded.\n");
         }
         curl_easy_cleanup(curl_handle);
     }


### PR DESCRIPTION
## Summary
- fetch malware signatures from the Signature-base hash feed
- parse the text feed into the signature database
- update documentation to reflect new source

## Testing
- `make`
- `./antivirus test` *(terminated after verifying signature load)*

------
https://chatgpt.com/codex/tasks/task_e_6852ca22180c8329ae3ba4d90602d583